### PR TITLE
Added Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 /.tox
 /docs/_build/
 /dist
+# Nix flake build artefacts
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718160348,
+        "narHash": "sha256-9YrUjdztqi4Gz8n3mBuqvCkMo4ojrA6nASwyIKWMpus=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "57d6973abba7ea108bac64ae7629e7431e0199b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "PiShock python tool flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        packages.default = with pkgs.python3Packages;
+          buildPythonPackage rec {
+            propagatedBuildInputs = [
+              requests
+              platformdirs
+              rich
+              typer
+              typing-extensions
+              pyserial
+              pkgs.esptool
+            ];
+
+            pname = "pishock";
+            version = "1.0.3";
+            format = "wheel";
+
+            src = fetchPypi rec {
+              inherit pname version format;
+              sha256 =
+                "952ba845d04a5fa4409409fed401d693be910dc5bb9049e2508aa87cb8049f77";
+              dist = python;
+              python = "py3";
+              abi = "none";
+              platform = "any";
+            };
+          };
+      });
+}


### PR DESCRIPTION
NIx flake to package the PiShock tool for Nix systems. esptool is also bundled for flashing.

Using this flake, Nix users will can add the pishock command to their environment, or create ephemeral shells where the command can be used.

### Testing
This can be tested manually on any machine that has access to the Nix package manager. The ability to build can be proven with the `nix build` command in the same directory as the flake, and `nix shell` will create a shell where the pishock command will be available. Adding the flake to your nix configuration will make the command available in the users default environment. Enabling flake support may be required.

### Considerations
This implementation packages the wheel package from pypi, and pulls in python package dependencies from nixpkgs-unstable. These versions are pinned in the `flake.lock` file. This approach works, but does not necessarily use dependency versions tested by upstream. Therefore I would be happy to work in this PR to use poetry2nix, which will be able to package using python dependencies from `poetry.lock`.

Additionally, I am using flake-utils to target all platforms supported by Nix. However I hove only been able to test with x86_64-linux. If you see reason to exclude or limit to specific platforms, let me know.